### PR TITLE
Allow for a large number of URL matches

### DIFF
--- a/routes/mapper.py
+++ b/routes/mapper.py
@@ -594,7 +594,10 @@ class Mapper(SubMapperParent):
         # Save the master regexp
         regexp = '|'.join(['(?:%s)' % x for x in regexps])
         self._master_reg = regexp
-        self._master_regexp = re.compile(regexp)
+        try:
+            self._master_regexp = re.compile(regexp)
+        except OverflowError:
+            self._master_regexp = None
         self._created_regs = True
     
     def _match(self, url, environ):
@@ -631,9 +634,15 @@ class Mapper(SubMapperParent):
         domain_match = self.domain_match
         debug = self.debug
         
-        # Check to see if its a valid url against the main regexp
-        # Done for faster invalid URL elimination
-        valid_url = re.match(self._master_regexp, url)
+        if self._master_regexp is not None:
+            # Check to see if its a valid url against the main regexp
+            # Done for faster invalid URL elimination
+            valid_url = re.match(self._master_regexp, url)
+        else:
+            # Regex is None due to OverflowError caused by too many routes.
+            # This will allow larger projects to work but might increase time
+            # spent invalidating URLs in the loop below.
+            valid_url = True
         if not valid_url:
             return (None, None, matchlog)
         

--- a/tests/test_functional/test_utils.py
+++ b/tests/test_functional/test_utils.py
@@ -158,6 +158,12 @@ class TestUtils(unittest.TestCase):
         eq_('/post/index/4', url.current(controller='post'))
         eq_('http://www.example.com:8080/blog/view/4', url.current(qualified=True))
         
+    def test_route_overflow(self):
+        m = self.con.mapper
+        m.create_regs(["x"*50000])
+        m.connect('route-overflow', "x"*50000)
+        url = URLGenerator(m, {})
+        eq_("/%s" % ("x"*50000), url('route-overflow'))
     
     def test_with_route_names(self):
         m = self.con.mapper


### PR DESCRIPTION
Currently routes/regex raises an OverflowError when compiling a master
list of 'valid' URLs if the number of controllers/routes is extremely
high. This error can be worked around by assuming all URLs are good
until all matches have been tested.

This means that on large projects performance will be slightly
increased with valid requests and slightly decreased with invalid
requests.
