### PR TITLE
Extract Route creation into separate method

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,9 @@
 Routes Changelog
 %%%%%%%%%%%%%%%%
 
+* Extract Route creation into separate method in Mapper.  Subclasses of Route
+  can be created by Mappers now.
+
 Release 2.0 (November 17, 2013)
 ===============================
 * Python 3.2/3.3 Support. Fixes Issue #2. Thanks to Alejandro Sánchez for

--- a/routes/mapper.py
+++ b/routes/mapper.py
@@ -460,6 +460,13 @@ class Mapper(SubMapperParent):
                 routepath = route.routepath
             self.connect(route.name, routepath, **route._kargs)
                 
+    def make_route(self, *args, **kargs):
+        """Make a new Route object
+
+        A subclass can override this method to use a custom Route class.
+        """
+        return Route(*args, **kargs)
+
     def connect(self, *args, **kargs):
         """Create and connect a new Route to the Mapper.
         
@@ -486,7 +493,7 @@ class Mapper(SubMapperParent):
             kargs['_explicit'] = self.explicit
         if '_minimize' not in kargs:
             kargs['_minimize'] = self.minimization
-        route = Route(*args, **kargs)
+        route = self.make_route(*args, **kargs)
                 
         # Apply encoding and errors if its not the defaults and the route 
         # didn't have one passed in.


### PR DESCRIPTION
Allow a Mapper subclass to use a different Route implementation.