### PR TITLE
Concat fix

### DIFF
--- a/routes/mapper.py
+++ b/routes/mapper.py
@@ -116,7 +116,19 @@ class SubMapperParent(object):
             controller = resource_name or collection_name
 
         if path_prefix is None:
-            path_prefix = '/' + collection_name
+            if collection_name is None:
+                path_prefix_str = ''
+            else:
+                path_prefix_str = '/{collection_name}'
+        else:
+            if collection_name is None:
+                path_prefix_str = "{pre}"
+            else:
+                path_prefix_str = "{pre}/{collection_name}"
+
+        # generate what will be the path prefix for the collection
+        path_prefix = path_prefix_str.format(pre=path_prefix,
+                                             collection_name=collection_name)
 
         collection = SubMapper(self, collection_name=collection_name,
                                resource_name=resource_name,
@@ -148,30 +160,44 @@ class SubMapper(SubMapperParent):
             self.formatted = getattr(obj, 'formatted', None)
             if self.formatted is None:
                 self.formatted = True
-
-        self.add_actions(actions or [])
+        self.add_actions(actions or [], **kwargs)
 
     def connect(self, *args, **kwargs):
         newkargs = {}
-        newargs = args
+        # newargs = args
+        routename, path = args
         for key, value in six.iteritems(self.kwargs):
             if key == 'path_prefix':
                 if len(args) > 1:
-                    newargs = (args[0], self.kwargs[key] + args[1])
+                    # if there's a name_prefix, add it to the route name
+                    # and if there's a path_prefix
+                    path = ''.join((self.kwargs[key], args[1]))
                 else:
-                    newargs = (self.kwargs[key] + args[0],)
+                    path = ''.join((self.kwargs[key], args[0]))
+            elif key == 'name_prefix':
+                if len(args) > 1:
+                    # if there's a name_prefix, add it to the route name
+                    # and if there's a path_prefix
+                    routename = ''.join((self.kwargs[key], args[0]))
+                else:
+                    routename = None
             elif key in kwargs:
                 if isinstance(value, dict):
                     newkargs[key] = dict(value, **kwargs[key])  # merge dicts
-                elif key == 'controller':
-                    newkargs[key] = kwargs[key]
                 else:
-                    newkargs[key] = value + kwargs[key]
+                    # Originally used this form:
+                    # newkargs[key] = value + kwargs[key]
+                    # New version avoids the inheritance concatenation issue
+                    # with submappers. Only prefixes concatenate, everything
+                    # else overrides in submappers.
+                    newkargs[key] = kwargs[key]
             else:
                 newkargs[key] = self.kwargs[key]
         for key in kwargs:
             if key not in self.kwargs:
                 newkargs[key] = kwargs[key]
+
+        newargs = (routename, path)
         return self.obj.connect(*newargs, **newkargs)
 
     def link(self, rel=None, name=None, action=None, method='GET',
@@ -263,8 +289,8 @@ class SubMapper(SubMapperParent):
         """Generates the "delete" action for a collection member submapper."""
         return self.action(action='delete', method='DELETE', **kwargs)
 
-    def add_actions(self, actions):
-        [getattr(self, action)() for action in actions]
+    def add_actions(self, actions, **kwargs):
+        [getattr(self, action)(**kwargs) for action in actions]
 
     # Provided for those who prefer using the 'with' syntax in Python 2.5+
     def __enter__(self):

--- a/tests/test_functional/test_submapper.py
+++ b/tests/test_functional/test_submapper.py
@@ -154,6 +154,43 @@ class TestSubmapper(unittest.TestCase):
         match = m.match('/parents/1/children/2')
         eq_('col2', match.get('controller'))
 
+    def test_submapper_argument_overriding(self):
+        m = Mapper()
+        first = m.submapper(path_prefix='/first_level',
+                            controller='first', action='test',
+                            name_prefix='first_')
+        first.connect('test', r'/test')
+        second = first.submapper(path_prefix='/second_level',
+                                 controller='second',
+                                 name_prefix='second_')
+        second.connect('test', r'/test')
+        third = second.submapper(path_prefix='/third_level',
+                                 controller="third", action='third_action',
+                                 name_prefix='third_')
+        third.connect('test', r'/test')
+
+        # test first level
+        match = m.match('/first_level/test')
+        eq_('first', match.get('controller'))
+        eq_('test', match.get('action'))
+        # test name_prefix worked
+        eq_('/first_level/test', url_for('first_test'))
+
+        # test second level controller override
+        match = m.match('/first_level/second_level/test')
+        eq_('second', match.get('controller'))
+        eq_('test', match.get('action'))
+        # test name_prefix worked
+        eq_('/first_level/second_level/test', url_for('first_second_test'))
+
+        # test third level controller and action override
+        match = m.match('/first_level/second_level/third_level/test')
+        eq_('third', match.get('controller'))
+        eq_('third_action', match.get('action'))
+        # test name_prefix worked
+        eq_('/first_level/second_level/third_level/test',
+             url_for('first_second_third_test'))
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Hi Ben,

I've been using Routes for a while with my semi-custom web framework (I know, I know, why on earth?! I'm a weirdo :) ). I often use submappers to DRY up my routes and am a fan of the modular routing it enables.

When I first started using them I ran into some behaviors I thought seemed non-intuitive. I opened an issue on the old bit-bucket hosted version of routes (a few years ago) but ended up creating my own github fork of your repo to make some changes. Now that routes is on github and accepting pull requests, I went ahead and re-forked 'officially' from your github repo and thought I'd offer these changes to you for routes (if you agree with my thinking and I'm not overlooking something).

The issue I ran into has to do with submappers not allowing overriding arguments at lower levels of the nesting in submappers and arguments concatenating in ways that I didn't expect.

Here's a contrived example to show the issue:
```
from webob import Request
from routes import Mapper
mapper = Mapper(explicit=False)

with mapper.submapper(controller="experiment", path_prefix="/exp") as exp:
    exp.connect('test', r'/test')
    with exp.submapper(controller="other", path_prefix="/other") as other:
        other.connect('test2', r'/zing')
        other.connect('test3', r'/parrot', controller="parrot")

print mapper

print
print "Results in the following Mappings:"
for url in ('/exp/test', '/exp/other/zing', '/exp/other/parrot'):
    request = Request.blank(url)
    match, route = mapper.routematch(environ=request.environ)
    print "{url:20} - {match}".format(url=url, match=match)

```

This generates the routes you would expect but the matched vars seem surprising.
```
Route name Methods Path
test               /exp/test
test2              /exp/other/zing
test3              /exp/other/parrot

Results in the following Mappings:
/exp/test            - {'action': u'index', 'controller': u'experiment'}
/exp/other/zing      - {'action': u'index', 'controller': u'experimentother'}
/exp/other/parrot    - {'action': u'index', 'controller': u'experimentotherparrot'}
```

The controller url variable that's returned is the **concatenation** of all of the controller keyword arguments in the nested hierarchy.

The concatenting logic makes sense when dealing with generative prefix arguments (name_prefix and path_prefix) but that seems like the special case rather than the general case.

The fix seems simple enough, make the 'prefix' arguments generative and the special case. If the keyword argument value isn't a dict (and therefore merged) then just override the keyword argument with the new argument. This means the prefix arguments concatenate and nest, and any other arguments can be overridden at any lower level of the submapper nesting.

I also had to add a minor fix for collections to work with no name when being used in a submapper context with no collection_name specified.

Thoughts?

(the .gitignore cruft is from my original uploading of my bitbucket -> github fork a few years ago)
