### PR TITLE
Take first component of X-Forwarded-{Proto,Host}

### DIFF
--- a/routes/__init__.py
+++ b/routes/__init__.py
@@ -59,7 +59,10 @@ class _RequestConfig(object):
             pass
         
         if 'HTTP_X_FORWARDED_HOST' in environ:
-            self.__shared_state.host = environ['HTTP_X_FORWARDED_HOST']
+            # Apache will add multiple comma separated values to
+            # X-Forwarded-Host if there are multiple reverse proxies
+            self.__shared_state.host = \
+                environ['HTTP_X_FORWARDED_HOST'].split(', ', 1)[0]
         elif 'HTTP_HOST' in environ:
             self.__shared_state.host = environ['HTTP_HOST']
         else:

--- a/routes/util.py
+++ b/routes/util.py
@@ -460,12 +460,12 @@ def cache_hostinfo(environ):
     """
     hostinfo = {}
     if environ.get('HTTPS') or environ.get('wsgi.url_scheme') == 'https' \
-       or environ.get('HTTP_X_FORWARDED_PROTO') == 'https':
+       or 'https' in environ.get('HTTP_X_FORWARDED_PROTO').split(', '):
         hostinfo['protocol'] = 'https'
     else:
         hostinfo['protocol'] = 'http'
     if environ.get('HTTP_X_FORWARDED_HOST'):
-        hostinfo['host'] = environ['HTTP_X_FORWARDED_HOST']
+        hostinfo['host'] = environ['HTTP_X_FORWARDED_HOST'].split(', ', 1)[0]
     elif environ.get('HTTP_HOST'):
         hostinfo['host'] = environ['HTTP_HOST']
     else:


### PR DESCRIPTION
Apache will add comma separated components to X-Forwarded-{For,Host,Proto} if the header already exists,
i.e. if there are multiple reverse proxies. Apache docs: http://httpd.apache.org/docs/2.4/mod/mod_proxy.html#x-headers

Fixes issue #5 