### PR TITLE
Minor fix in docs

### DIFF
--- a/docs/setting_up.rst
+++ b/docs/setting_up.rst
@@ -84,7 +84,7 @@ backslashes.  Without the R you'd have to double every backslash.
 
 Another example::
 
-    m.connect("archives/{year}/{month}/{day}", controller="archives",
+    m.connect("/archives/{year}/{month}/{day}", controller="archives",
               action="view", year=2004,
               requirements=dict(year=R"\d{2,4}", month=R"\d{1,2}"))
 
@@ -344,6 +344,7 @@ Adding routes from a nested application
 gives the parent a list of routes to add to its mapper.  These can be added
 with the ``.extend`` method, optionally providing a path prefix::
 
+    from routes.route import Route
     routes = [
         Route("index", "/index.html", controller="home", action="index"),
         ]


### PR DESCRIPTION
As the doc says "Route paths should always begin with a slash."

Add a import statement in example code, since in that place it's the first time mention this class and user can't understand what "Route" class is.