### PR TITLE
Issue #42: Fix compilation of docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -91,7 +91,7 @@ pygments_style = 'sphinx'
 # typographically correct entities.
 #html_use_smartypants = True
 
-
+html_theme = 'classic'
 html_theme_options = {
     "bgcolor": "#fff",
     "footertextcolor": "#666",

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -65,6 +65,7 @@ Documentation
    restful
    uni_redirect_rest
    changes
+   todo
 
 .. toctree::
    :maxdepth: 1


### PR DESCRIPTION
* Set the HTML theme to 'classic' to fix the error:
  "unsupported theme option 'relbarlinkcolor' given"
* Add tox.ini to easily run tests on Python 2.7 and 3.4, and to compile
  documentation: tox installs requirements. Use "tox -e docs" to compile
  the documentation, the docs directory is always cleaned up.
* Add todo.rst to the documentation (add it to TOC in the index)