### PR TITLE
Fix BytesWarning in Mapper.generate()

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,4 +14,4 @@ matrix:
 install:
   - python setup.py develop
   - pip install webob webtest coverage
-script: nosetests
+script: python -bb $(which nosetests)

--- a/routes/mapper.py
+++ b/routes/mapper.py
@@ -789,7 +789,11 @@ class Mapper(SubMapperParent):
             six.text_type(kargs).encode('utf8')
 
         if self.urlcache is not None:
-            cache_key_script_name = '%s:%s' % (script_name, cache_key)
+            if six.PY3:
+                cache_key_script_name = b':'.join((script_name.encode('utf-8'),
+                                                   cache_key))
+            else:
+                cache_key_script_name = '%s:%s' % (script_name, cache_key)
 
             # Check the url cache to see if it exists, use it if it does
             val = self.urlcache.get(cache_key_script_name, self)


### PR DESCRIPTION
When python3 is run with -bb, str(bytes) raises a BytesWarning. On
Python 3, Mapper.generate() gets such BytesWarning because
script_name type is str whereas cache_key type is byte.

On Python 3, generate() now encodes the script_name to UTF-8 and uses
bytes concatenation to fix this issue.

To test the patch, run tests using "python3 -bb". For example using my tox patch:

```
$ . .tox/py3/bin/activate
(py3)$ python -bb $(which nosetests) tests/
```