### PR TITLE
Fix empty string match

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,13 @@ python:
   - "2.7"
   - "3.3"
   - "3.4"
+  - "3.5"
+  - "nightly"
   - "pypy"
   - "pypy3"
+matrix:
+  allow_failures:
+    - python: "nightly"
 install:
   - python setup.py develop
   - pip install webob webtest coverage

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,10 +3,10 @@ Routes Changelog
 
 Release 2.3 (**dev**)
 =====================
-
+* Fix matching of an empty string route, which led to exception in earlier
+  versions. PR #58. Patch by Sviatoslav Sydorenko.
 * Add support for the ``requirements`` option when using
   mapper.resource to create routes. PR #57. Patch by Sean Dague.
-
 * Concatenation fix when using submappers with path prefixes. Multiple
   submappers combined the path prefix inside the controller argument in
   non-obvious ways. The controller argument will now be properly carried

--- a/routes/mapper.py
+++ b/routes/mapper.py
@@ -713,10 +713,10 @@ class Mapper(SubMapperParent):
             resultdict = m.match('/joe/sixpack')
 
         """
-        if not url and not environ:
+        if url is None and not environ:
             raise RoutesException('URL or environ must be provided')
 
-        if not url:
+        if url is None:
             url = environ['PATH_INFO']
 
         result = self._match(url, environ)
@@ -737,10 +737,10 @@ class Mapper(SubMapperParent):
             resultdict, route_obj = m.match('/joe/sixpack')
 
         """
-        if not url and not environ:
+        if url is None and not environ:
             raise RoutesException('URL or environ must be provided')
 
-        if not url:
+        if url is None:
             url = environ['PATH_INFO']
         result = self._match(url, environ)
         if self.debug:

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,8 @@ setup(name="Routes",
                    "Programming Language :: Python :: 3",
                    "Programming Language :: Python :: 3.2",
                    "Programming Language :: Python :: 3.3",
-                   "Programming Language :: Python :: 3.4"
+                   "Programming Language :: Python :: 3.4",
+                   "Programming Language :: Python :: 3.5"
                    ],
       keywords='routes webob dispatch',
       author="Ben Bangert",

--- a/tests/test_functional/test_recognition.py
+++ b/tests/test_functional/test_recognition.py
@@ -913,7 +913,7 @@ class TestRecognition(unittest.TestCase):
         eq_({'controller':'content','action':'index','id':None}, m.match('/content'))
         eq_({'controller':'content','action':'view','id':'4'}, m.match('/'))
         def call_func():
-            m.match('')
+            m.match(None)
         assert_raises(RoutesException, call_func)
 
     def test_home_noargs(self):
@@ -926,7 +926,7 @@ class TestRecognition(unittest.TestCase):
         eq_(None, m.match('/content'))
         eq_({}, m.match('/'))
         def call_func():
-            m.match('')
+            m.match(None)
         assert_raises(RoutesException, call_func)
 
     def test_dot_format_args(self):


### PR DESCRIPTION
Hi,
I've found a bug while using `cherrypy` framework.

When `mapper.routematch('')` is called (internally inside of `cherrypy`) `Routes` raise `RoutesException('URL or environ must be provided')`, which is wrong. I've registered URL handler for that route and it has to resolve.

```
Traceback (most recent call last):
  File "/home/wk/src/pyenv-3.5/lib/python3.5/site-packages/cherrypy/_cprequest.py", line 642, in respond
    self.get_resource(path_info)
  File "/home/wk/src/pyenv-3.5/lib/python3.5/site-packages/cherrypy/_cprequest.py", line 760, in get_resource
    dispatch(path)
  File "/home/wk/src/pyenv-3.5/lib/python3.5/site-packages/cherrypy/_cpdispatch.py", line 524, in __call__
    func = self.find_handler(path_info)
  File "/home/wk/src/pyenv-3.5/lib/python3.5/site-packages/cherrypy/_cpdispatch.py", line 539, in find_handler
    config.environ = request.wsgi_environ
  File "/home/wk/src/pyenv-3.5/lib/python3.5/site-packages/routes/__init__.py", line 23, in __setattr__
    self.load_wsgi_environ(value)
  File "/home/wk/src/pyenv-3.5/lib/python3.5/site-packages/routes/__init__.py", line 52, in load_wsgi_environ
    result = mapper.routematch(path)
  File "/home/wk/src/pyenv-3.5/lib/python3.5/site-packages/routes/mapper.py", line 715, in routematch
    raise RoutesException('URL or environ must be provided')
routes.util.RoutesException: URL or environ must be provided
```

This PR fixes that.