### PR TITLE
Fix #38: Add webob dependency [optional]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ html_coverage
 .idea
 *.iml
 .tox/
+.eggs/
+.coverage

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,8 @@ Routes Changelog
 
 Release 2.3 (**dev**)
 =====================
+* Add support for the ``middleware`` extra requirement, making possible to
+  depend on ``webob`` optionally. PR #59. Patch by Sviatoslav Sydorenko.
 * Fix matching of an empty string route, which led to exception in earlier
   versions. PR #58. Patch by Sviatoslav Sydorenko.
 * Add support for the ``requirements`` option when using

--- a/docs/modules/middleware.rst
+++ b/docs/modules/middleware.rst
@@ -2,7 +2,6 @@
 ==================================================
 
 .. automodule:: routes.middleware
-.. currentmodule:: routes.middleware
 
 Module Contents
 ---------------

--- a/routes/middleware.py
+++ b/routes/middleware.py
@@ -12,7 +12,12 @@ log = logging.getLogger('routes.middleware')
 
 class RoutesMiddleware(object):
     """Routing middleware that handles resolving the PATH_INFO in
-    addition to optionally recognizing method overriding."""
+    addition to optionally recognizing method overriding.
+    
+    .. Note::
+        This module requires webob to be installed. To depend on it, you may
+        list routes[middleware] in your ``requirements.txt``
+    """
     def __init__(self, wsgi_app, mapper, use_method_override=True,
                  path_info=True, singleton=True):
         """Create a Route middleware object

--- a/setup.py
+++ b/setup.py
@@ -57,5 +57,10 @@ setup(name="Routes",
           "six",
           "repoze.lru>=0.3"
       ],
+      extras_require={
+          'middleware': [
+              'webob',
+          ]
+      },
       **extra_options
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,17 +1,13 @@
 [tox]
-envlist = py26,py27,py33,py34,pypy,pypy3
+envlist = py26,py27,py33,py34,py35,pypy,pypy3
 
 [testenv]
 deps=
-    coverage
-    nose
-    webob
-    webtest
+    nose  # Adds nosetests command to setup.py
 commands=
-    python -bb -m nose tests {posargs}
+    python -bb setup.py nosetests {posargs:--with-coverage}
 
-[testenv:py26]
-# Ony Python 2.6, python -m test doesn't work. Anyway, python -bb is only
-# interested on Python 3.
-commands=
-    nosetests tests {posargs}
+    # We could to this in dependencies, but explicit is better than implicit
+    pip install .[middleware]
+    # webob optional dependency is fulfilled by [middleware] extra requirement
+    python -c "import webob"


### PR DESCRIPTION
Implement #38. Now it is possible to pull `webob` automatically by depending on `middleware` extra requirement.

Examples:

    pip install routes[middleware]
    pip install git+https://github.com/webknjaz/routes@a1b8659#egg=routes[middleware]