### PR TITLE
Fix subdomain equivalence check

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,7 @@ Routes Changelog
 
 Release 2.3 (**dev**)
 =====================
+* Fix sub_domain equivalence check. Patch by Nikita Uvarov
 * Add support for protocol-relative URLs generation (i.e. starting with double
   slash ``//``). PR #60. Patch by Sviatoslav Sydorenko.
 * Add support for the ``middleware`` extra requirement, making possible to

--- a/routes/util.py
+++ b/routes/util.py
@@ -93,10 +93,12 @@ def _subdomain_check(kargs, mapper, environ):
         port = ''
         if len(hostmatch) > 1:
             port += ':' + hostmatch[1]
-        sub_match = re.compile('^.+?\.(%s)$' % mapper.domain_match)
-        domain = re.sub(sub_match, r'\1', host)
+
+        match = re.match('^(.+?)\.(%s)$' % mapper.domain_match, host)
+        host_subdomain, domain = match.groups() if match else (None, host)
+
         subdomain = as_unicode(subdomain, mapper.encoding)
-        if subdomain and not host.startswith(subdomain) and \
+        if subdomain and host_subdomain != subdomain and \
             subdomain not in mapper.sub_domains_ignore:
             kargs['_host'] = subdomain + '.' + domain + port
         elif (subdomain in mapper.sub_domains_ignore or \

--- a/tests/test_functional/test_explicit_use.py
+++ b/tests/test_functional/test_explicit_use.py
@@ -52,6 +52,14 @@ class TestUtils(unittest.TestCase):
         url = URLGenerator(m, environ.copy())
         assert_raises(GenerationException, lambda: url.current(qualified=True))
 
+        environ = {'HTTP_HOST': 'subdomain.localhost.com'}
+        url = URLGenerator(m, environ.copy())
+        eq_('http://sub.localhost.com/hi/smith', url(fred='smith', sub_domain='sub', qualified=True))
+
+        environ = {'HTTP_HOST': 'sub.sub.localhost.com'}
+        url = URLGenerator(m, environ.copy())
+        eq_('http://new.localhost.com/hi/smith', url(fred='smith', sub_domain='new', qualified=True))
+
         url = URLGenerator(m, {})
         eq_('/hi/smith', url(fred='smith', sub_domain=u'home'))
 


### PR DESCRIPTION
Problem occurred when new subdomain was left substring of current one.
In this case subdomain was not replaced.