### PR TITLE
Tolerate older usage with mandatory routename and optional path

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,11 @@
 Routes Changelog
 %%%%%%%%%%%%%%%%
 
+Release 2.3.1 (**dev**)
+=======================
+* Backwards compatability fix - connect should work with mandatory
+  routename and optional path. Patch by Davanum Srinivas (PR #65).
+
 Release 2.3 (March 28, 2016)
 ============================
 * Fix sub_domain equivalence check. Patch by Nikita Uvarov

--- a/routes/mapper.py
+++ b/routes/mapper.py
@@ -162,25 +162,25 @@ class SubMapper(SubMapperParent):
                 self.formatted = True
         self.add_actions(actions or [], **kwargs)
 
-    def connect(self, *args, **kwargs):
+    def connect(self, routename, path=None, **kwargs):
         newkargs = {}
-        # newargs = args
-        routename, path = args
+        _routename = routename
+        _path = path
         for key, value in six.iteritems(self.kwargs):
             if key == 'path_prefix':
-                if len(args) > 1:
+                if path is not None:
                     # if there's a name_prefix, add it to the route name
                     # and if there's a path_prefix
-                    path = ''.join((self.kwargs[key], args[1]))
+                    _path = ''.join((self.kwargs[key], path))
                 else:
-                    path = ''.join((self.kwargs[key], args[0]))
+                    _path = ''.join((self.kwargs[key], routename))
             elif key == 'name_prefix':
-                if len(args) > 1:
+                if path is not None:
                     # if there's a name_prefix, add it to the route name
                     # and if there's a path_prefix
-                    routename = ''.join((self.kwargs[key], args[0]))
+                    _routename = ''.join((self.kwargs[key], routename))
                 else:
-                    routename = None
+                    _routename = None
             elif key in kwargs:
                 if isinstance(value, dict):
                     newkargs[key] = dict(value, **kwargs[key])  # merge dicts
@@ -197,7 +197,7 @@ class SubMapper(SubMapperParent):
             if key not in self.kwargs:
                 newkargs[key] = kwargs[key]
 
-        newargs = (routename, path)
+        newargs = (_routename, _path)
         return self.obj.connect(*newargs, **newkargs)
 
     def link(self, rel=None, name=None, action=None, method='GET',

--- a/tests/test_functional/test_submapper.py
+++ b/tests/test_functional/test_submapper.py
@@ -13,6 +13,12 @@ class TestSubmapper(unittest.TestCase):
         eq_('/entries/1', url_for('entry', id=1))
         assert_raises(Exception, url_for, 'entry', id='foo')
 
+    def test_submapper_with_no_path(self):
+        m = Mapper()
+        c = m.submapper(path_prefix='/')
+        c.connect('entry')
+        eq_('/entry?id=1', url_for('entry', id=1))
+
     def test_submapper_nesting(self):
         m = Mapper()
         c = m.submapper(path_prefix='/entries', controller='entry',


### PR DESCRIPTION
With the following review:
https://github.com/bbangert/routes/commit/0a417004be7e2d950bdcd629ccf24cf9f56ef817

Routes 2.3 has changed the function signature to mandate
path in addition to routename for the connect method.

In this patch, we try to get back to path being optional by
checking the length of the args list. No other change in
logic.

This hopefully fixes the problem reported here:
https://github.com/bbangert/routes/issues/64