### PR TITLE
Fix missing quotes in documentation

### DIFF
--- a/routes/mapper.py
+++ b/routes/mapper.py
@@ -1230,7 +1230,7 @@ class Mapper(SubMapperParent):
         Example::
 
             map = Mapper()
-            map.redirect('/legacyapp/archives/{url:.*}, '/archives/{url})
+            map.redirect('/legacyapp/archives/{url:.*}', '/archives/{url}')
             map.redirect('/home/index', '/',
                          _redirect_code='301 Moved Permanently')
 


### PR DESCRIPTION
When reading the docs I discovered a missing set of single quotes in
this code example which makes the example invalid python code. Fixed.