### PR TITLE
Remove obsolete Python 2.3 compat code

### DIFF
--- a/routes/route.py
+++ b/routes/route.py
@@ -1,7 +1,5 @@
 import re
 import sys
-if sys.version < '2.4':
-    from sets import ImmutableSet as frozenset
 
 import six
 from six.moves.urllib import parse as urlparse


### PR DESCRIPTION
Python 2.3 hasn't been supported for a very long time...