### PR TITLE
Allow backslash to escape special characters \:*{} in route paths

### DIFF
--- a/routes/route.py
+++ b/routes/route.py
@@ -148,13 +148,22 @@ class Route(object):
         """Utility function to walk the route, and pull out the valid
         dynamic/wildcard keys."""
         collecting = False
+        escaping = False
         current = ''
         done_on = ''
         var_type = ''
         just_started = False
         routelist = []
         for char in routepath:
-            if char in [':', '*', '{'] and not collecting and not self.static \
+            if escaping:
+                if char in ['\\', ':', '*', '{', '}']:
+                    current += char
+                else:
+                    current += '\\' + char
+                escaping = False
+            elif char == '\\':
+                escaping = True
+            elif char in [':', '*', '{'] and not collecting and not self.static \
                or char in ['{'] and not collecting:
                 just_started = True
                 collecting = True

--- a/tests/test_units/test_route_escapes.py
+++ b/tests/test_units/test_route_escapes.py
@@ -1,0 +1,31 @@
+import unittest
+from routes.route import Route
+
+class TestRouteEscape(unittest.TestCase):
+    def test_normal_route(self):
+        r = Route('test', '/foo/bar')
+        self.assertEqual(r.routelist, ['/foo/bar'])
+
+    def test_route_with_backslash(self):
+        r = Route('test', '/foo\\\\bar')
+        self.assertEqual(r.routelist, ['/foo\\bar'])
+
+    def test_route_with_random_escapes(self):
+        r = Route('test', '\\/f\\oo\\/ba\\r')
+        self.assertEqual(r.routelist, ['\\/f\\oo\\/ba\\r'])
+
+    def test_route_with_colon(self):
+        r = Route('test', '/foo:bar/baz')
+        self.assertEqual(r.routelist, ['/foo', {'name': 'bar', 'type': ':'}, '/', 'baz'])
+
+    def test_route_with_escaped_colon(self):
+        r = Route('test', '/foo\\:bar/baz')
+        self.assertEqual(r.routelist, ['/foo:bar/baz'])
+
+    def test_route_with_both_colons(self):
+        r = Route('test', '/prefix/escaped\\:escaped/foo=:notescaped/bar=42')
+        self.assertEqual(r.routelist, ['/prefix/escaped:escaped/foo=', {'name': 'notescaped', 'type': ':'}, '/', 'bar=42'])
+
+    def test_route_with_all_escapes(self):
+        r = Route('test', '/hmm\\:\\*\\{\\}*star/{brackets}/:colon')
+        self.assertEqual(r.routelist, ['/hmm:*{}', {'name': 'star', 'type': '*'}, '/',  {'name': 'brackets', 'type': ':'}, '/', {'name': 'colon', 'type': ':'}])


### PR DESCRIPTION
This allows the sequences `\\ \: \* \{ \}` to be replaced with their second characters, bypassing further token processing. Should help with #82 and #79 where %-processing is not done. Not sure how well it plays with untested complex routes, but the tests pass. 