### PR TITLE
[doc] Fixed default value for `minimization` in Mapper doc

### DIFF
--- a/routes/mapper.py
+++ b/routes/mapper.py
@@ -381,7 +381,7 @@ class Mapper(SubMapperParent):
         ``minimization``
             Boolean used to indicate whether or not Routes should
             minimize URL's and the generated URL's, or require every
-            part where it appears in the path. Defaults to True.
+            part where it appears in the path. Defaults to False.
 
         ``hardcode_names``
             Whether or not Named Routes result in the default options


### PR DESCRIPTION
`Mapper.minimization` defaults to `False`, not to `True` :)