### PR TITLE
Convert regex string to raw string

### DIFF
--- a/routes/mapper.py
+++ b/routes/mapper.py
@@ -409,7 +409,7 @@ class Mapper(SubMapperParent):
         self.append_slash = False
         self.sub_domains = False
         self.sub_domains_ignore = []
-        self.domain_match = '[^\.\/]+?\.[^\.\/]+'
+        self.domain_match = r'[^\.\/]+?\.[^\.\/]+'
         self.explicit = explicit
         self.encoding = 'utf-8'
         self.decode_errors = 'ignore'


### PR DESCRIPTION
This marks a regex string as a raw string to avoid deprecation warnings.

Closes 84