### PR TITLE
remove apostrophe from "URLs"

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,6 @@
 Routes is a Python re-implementation of the Rails routes system for mapping
-URL's to Controllers/Actions and generating URL's. Routes makes it easy to
-create pretty and concise URL's that are RESTful with little effort.
+URLs to Controllers/Actions and generating URLs. Routes makes it easy to
+create pretty and concise URLs that are RESTful with little effort.
 
 Speedy and dynamic URL generation means you get a URL with minimal cruft
 (no big dangling query args). Shortcut features like Named Routes cut down

--- a/docs/restful.rst
+++ b/docs/restful.rst
@@ -59,7 +59,7 @@ This establishes the following convention::
 
 .. note::
 
-    Due to how Routes matches a list of URL's, it has no inherent knowledge of
+    Due to how Routes matches a list of URLs, it has no inherent knowledge of
     a route being a **resource**. As such, if a route fails to match due to
     the method requirements not being met, a 404 will return just like any
     other failure to match a route.

--- a/routes/mapper.py
+++ b/routes/mapper.py
@@ -372,7 +372,7 @@ class Mapper(SubMapperParent):
 
         ``encoding``
             Used to indicate alternative encoding/decoding systems to
-            use with both incoming URL's, and during Route generation
+            use with both incoming URLs, and during Route generation
             when passed a Unicode string. Defaults to 'utf-8'.
 
         ``decode_errors``
@@ -382,7 +382,7 @@ class Mapper(SubMapperParent):
 
         ``minimization``
             Boolean used to indicate whether or not Routes should
-            minimize URL's and the generated URL's, or require every
+            minimize URLs and the generated URLs, or require every
             part where it appears in the path. Defaults to False.
 
         ``hardcode_names``

--- a/routes/util.py
+++ b/routes/util.py
@@ -285,7 +285,7 @@ def url_for(*args, **kargs):
 
 
 class URLGenerator(object):
-    """The URL Generator generates URL's
+    """The URL Generator generates URLs
 
     It is automatically instantiated by the RoutesMiddleware and put
     into the ``wsgiorg.routing_args`` tuple accessible as::
@@ -297,7 +297,7 @@ class URLGenerator(object):
         url = environ['routes.url']
 
     The url object may be instantiated outside of a web context for use
-    in testing, however sub_domain support and fully qualified URL's
+    in testing, however sub_domain support and fully qualified URLs
     cannot be generated without supplying a dict that must contain the
     key ``HTTP_HOST``.
 


### PR DESCRIPTION
The plural form of "URL" is "URLs" without an apostrophe.