### PR TITLE
README: fix GitHub Actions CI link

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -9,5 +9,5 @@ on repetitive typing.
 See `the documentation for installation and usage of Routes <http://readthedocs.org/docs/routes/en/latest/>`_.
 
 .. image:: https://github.com/bbangert/routes/workflows/Python%20package/badge.svg?branch=main&event=push
-   :target: https://github.com/cherrypy/cheroot/actions?query=workflow%3A%22Python+package%22+branch%3Amaster
+   :target: https://github.com/bbangert/routes/actions?query=workflow%3A%22Python+package%22+branch%3Amain
    :alt: GitHub Actions Workflows CI/CD


### PR DESCRIPTION
Fix a bad copy-and-paste from another project.